### PR TITLE
Fix image resize toggling.

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -285,6 +285,7 @@ textAngular.directive("textAngular", [
 						event.preventDefault();
 					};
 
+					scope.displayElements.resize.anchors[3].off('mousedown');
 					scope.displayElements.resize.anchors[3].on('mousedown', _resizeMouseDown);
 
 					scope.reflowResizeOverlay(_el);

--- a/src/main.js
+++ b/src/main.js
@@ -295,6 +295,7 @@ textAngular.directive("textAngular", [
 				scope.hideResizeOverlay = function(){
 					scope.displayElements.resize.anchors[3].off('mousedown', _resizeMouseDown);
 					scope.displayElements.resize.overlay.css('display', '');
+					scope.updateTaBindtaTextElement();
 				};
 
 				// allow for insertion of custom directives on the textarea and div


### PR DESCRIPTION
When clicking an image the toolbar and resize overlay appears, clicking it again breaks it until the next edit operation. This patch fixes that by forcing an update.

Furthermore an issue where clicking multiple images can result in all images being resized, when attempting to resize just one.
