### PR TITLE
Update bindings when receiving focus.

### DIFF
--- a/src/taBind.js
+++ b/src/taBind.js
@@ -622,6 +622,7 @@ angular.module('textAngular.taBind', ['textAngular.factories', 'textAngular.DOM'
 					element.on('focus', scope.events.focus = function(){
 						_focussed = true;
 						element.removeClass('placeholder-text');
+						scope.updateTaBindtaTextElement();
 					});
 					
 					element.on('mouseup', scope.events.mouseup = function(){


### PR DESCRIPTION
Update bindings when we receive focus. This fixes image overlay not responding until some edit operation has been performed.
