### PR TITLE
Fix unittest failing

### DIFF
--- a/src/taBind.js
+++ b/src/taBind.js
@@ -622,7 +622,7 @@ angular.module('textAngular.taBind', ['textAngular.factories', 'textAngular.DOM'
 					element.on('focus', scope.events.focus = function(){
 						_focussed = true;
 						element.removeClass('placeholder-text');
-						scope.updateTaBindtaTextElement();
+						_reApplyOnSelectorHandlers();
 					});
 					
 					element.on('mouseup', scope.events.mouseup = function(){


### PR DESCRIPTION
Fix failing unit tests because `updateTaBindtaTextElement` is not
available inside `taBind` directive.
